### PR TITLE
Fixing self.host

### DIFF
--- a/rabbitmq_monitoring.py
+++ b/rabbitmq_monitoring.py
@@ -69,7 +69,7 @@ class RabitMQMonitoring():
     try:
         response = urllib2.urlopen(request)
     except urllib2.URLError as e:
-        sys.stderr.write("Error connecting to host: {0} ({1}), Error: {2}".format(self.host,e.errno,e.message))
+        sys.stderr.write("Error connecting to host: {0} ({1}), Error: {2}".format(self.hostname,e.errno,e.message))
         raise
     except urllib2.HTTPError as e:
         sys.stderr.write("Error getting data from AWS Cloud Watch API: %s (%d), Error: %s",


### PR DESCRIPTION
Found an error installing the plugin. 
self.host wasn't defined, assumed you meant to reference self.hostname.
