### PR TITLE
Add missing metric from plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -3,6 +3,7 @@
     "command": "python rabbitmq_monitoring.py",
     "icon": "icon.png",
     "metrics" : [
+                 "RABBITMQ_OBJECT_TOTALS_QUEUES",
                  "RABBITMQ_OBJECT_TOTALS_CHANNELS",
                  "RABBITMQ_OBJECT_TOTALS_EXCHANGES",
                  "RABBITMQ_OBJECT_TOTALS_CONSUMERS",


### PR DESCRIPTION
The metric RABBITMQ_OBJECT_TOTALS_QUEUES was missing from plugins.json. So when the plugin is installed the metric was not copied to the target account.
